### PR TITLE
退会のレイアウト崩れと不具合の修正

### DIFF
--- a/src/main/webapp/WEB-INF/view/withdrawal/withdrawal_confirm.html
+++ b/src/main/webapp/WEB-INF/view/withdrawal/withdrawal_confirm.html
@@ -35,12 +35,15 @@
 <main>
 <div class="contents">
 	<h2 class="content-title">Confirm Withdrawal Reasons</h2>
-	<section class="withdrawal-reason-select-box">
+	<section class="withdrawal-box">
 		<h3 class="content-title-second">Confirm your withdrawal reason</h3>
 		<form class="withdrawal-form" action="#" th:action="@{/withdrawal/done/}" method="post">
-			<span th:text="${reasonCode}">reasonCode</span> 
-			<span th:text="${reasonInput}">reasonInput</span>
-			<input type="hidden" name="reasonCode" th:value="${reasonCode}" />
+			<ul class="withdrawal-reason-list">
+				<li class="withdrawal-reason-element"><span th:text="${selectedReason}">reasonCode</span></li>
+				<li class="withdrawal-reason-element"><span th:text="${reasonInput}">reasonInput</span></li>
+			</ul>
+
+			<input type="hidden" name="selectedReason" th:value="${selectedReason}" />
 			<input type="hidden" name="reasonInput" th:value="${reasonInput}" />
 			<input type="submit" name="done" th:value="#{labels.finish}" />
 		</form>

--- a/src/main/webapp/WEB-INF/view/withdrawal/withdrawal_entry.html
+++ b/src/main/webapp/WEB-INF/view/withdrawal/withdrawal_entry.html
@@ -48,7 +48,7 @@
 				</li>
 				<li class="withdrawal-reason-element">
 					<div>Withdrawal Reason</div>
-					<textarea rows="3" cols="30" class="withdrawal-write-reason" name="reasonInput" />
+					<textarea rows="3" cols="30" class="withdrawal-write-reason" name="reasonInput"></textarea>
 					<span la:errors="reasonInput"></span>
 				</li>
 			</ul>

--- a/src/main/webapp/css/individual.css
+++ b/src/main/webapp/css/individual.css
@@ -187,10 +187,10 @@
                                                                                 Withdrawal
                                                                                 ------- */
 .withdrawal-box {
-	width: 420px;
-	margin: 32px auto;
+	width: 944px;
+	margin: 20px auto;
+	padding: 4px;
 	border: solid 4px #E5E5E5;
-	padding: 24px 64px;
 }
 .select-withdrawal-reason {
 	margin: 32px auto 0;


### PR DESCRIPTION
# 対応したこと

dbflute-example-on-springbootにWithdrawalを作ろうとして、harborのレイアウト崩れと不具合を見つけたので修正しました

## 修正前
- `textarea` が解釈できておらず、Confirmボタンが押せませんでした
- 余白やレイアウトが崩れていました
- 退会確認に、退会理由の区分値が表示されていませんでした

<img width="795" alt="スクリーンショット 2022-01-30 20 54 03" src="https://user-images.githubusercontent.com/7535130/155265071-6f9c3b45-cf95-45b2-9896-b047f5262dfa.png">

<img width="615" alt="スクリーンショット 2022-02-19 20 30 39" src="https://user-images.githubusercontent.com/7535130/155265082-00a7fb67-d04d-498f-9bda-b69827f1b177.png">

## 修正後
<img width="1007" alt="スクリーンショット 2022-02-23 14 34 38" src="https://user-images.githubusercontent.com/7535130/155266673-e793310b-b28d-42cf-bc07-43d8cdd0f710.png">

<img width="980" alt="スクリーンショット 2022-02-23 14 34 52" src="https://user-images.githubusercontent.com/7535130/155266679-352f0413-c1a0-48fe-9504-d0e1bcee7711.png">

