### PR TITLE
[dbflute users 2760] LastaFluteでパンチアウト連携  jacoco導入のexampleを作る

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,17 @@
 							<goal>report</goal>
 						</goals>
 					</execution>
+					<execution>
+						<id>report-from-exec</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<dataFile>${project.build.directory}/jacoco.exec</dataFile>
+							<outputDirectory>${project.build.directory}/site/jacoco</outputDirectory>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
# 対応したこと

[[dbflute users 2760] LastaFluteでパンチアウト連携](https://groups.google.com/g/dbflute/c/i0uT1h4H_sI) でjacocoが動かないとコメントいただいたので、exampleに追加してみました。
サンプルなので、必ずマージいただく必要はないと思い、Draft Pull Requestにしています。

## 参考

Github Copilotに助けてもらったので、プロンプトを貼っておきます

```
jacocoをインストールする方法を教えて
```
このプロンプトで作られたpomでは、jacoco.execが生成できましたが、レポートがありませんでした

```
jacoco.execからカバレッジレポートを作るのに必要なMaven pom.xmlの設定を教えて
```

jacoco.execからカバレッジレポートを出せるようになりました

# 実行結果

MySQLを起動した状態で `mvn clean verify` を実行すると、target/site/index.html にjacocoレポートが生成できました

![image](https://github.com/user-attachments/assets/eaadd94c-d20d-4bbf-bf36-79c9c934b6cb)

ログを見ると、jacoco.execを読み込めています。

```
[INFO] --- jacoco:0.8.10:report (report) @ harbor ---
[INFO] Loading execution data file /Users/yuko/IdeaProjects/lastaflute-example-harbor/target/jacoco.exec
```